### PR TITLE
Configure `publish` to ignore all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,5 +109,7 @@ workflows:
             - lint
             - test
           filters:
+            branches:
+              ignore: .*
             tags:
               only: /v[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,6 @@ workflows:
             - test
           filters:
             branches:
-              ignore: .*
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
I noticed that [all our builds were failing on `publish`](https://app.circleci.com/pipelines/github/groveco/json-api-tools) because we hadn't published the package (should we have even?) and don't bump the version on every merge to `master`, which is fine, since we only want to publish on a tagged release. However, [jobs execute against ALL branches by default](https://circleci.com/docs/2.0/configuration-reference/#branches-1) (emphasis added):

> Branches can have the keys `only` and `ignore` which either map to a single string naming a branch. You may also use regular expressions to match against branches by enclosing them with slashes, or map to a list of such strings. Regular expressions must match the entire string.
>
> - Any branches that match `only` will run the job.
> - Any branches that match `ignore` will not run the job.
> - **If neither `only` nor `ignore` are specified then _all branches_ will run the job.**
> - If both `only` and `ignore` are specified the `only` is considered before `ignore`.

If no `branches` are specified in the `filter`, the job runs as "if neither `only` nor `ignore` are specified". I ran into this on another Grove repo that was trying to publish on every build. Made the same mistake.